### PR TITLE
Better formatting of links and lists; more tests

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -38,6 +38,31 @@ func (ctx *textifyTraverseCtx) Traverse(node *html.Node) error {
 		case atom.Br:
 			return ctx.Emit("\n")
 
+		case atom.H1, atom.H2, atom.H3:
+			subCtx := textifyTraverseCtx{}
+			if err := subCtx.TraverseChildren(node); err != nil {
+				return err
+			}
+
+			str := subCtx.Buf.String()
+			dividerLen := 0
+			for _, line := range strings.Split(str, "\n") {
+				if lineLen := len([]rune(line)); lineLen-1 > dividerLen {
+					dividerLen = lineLen - 1
+				}
+			}
+			divider := ""
+			if node.DataAtom == atom.H1 {
+				divider = strings.Repeat("*", dividerLen)
+			} else {
+				divider = strings.Repeat("-", dividerLen)
+			}
+
+			if node.DataAtom == atom.H3 {
+				return ctx.Emit("\n\n" + str + "\n" + divider + "\n\n")
+			}
+			return ctx.Emit("\n\n" + divider + "\n" + str + "\n" + divider + "\n\n")
+
 		case atom.Li:
 			if err := ctx.Emit("* "); err != nil {
 				return err

--- a/html2text.go
+++ b/html2text.go
@@ -2,10 +2,13 @@ package html2text
 
 import (
 	"bytes"
-	"golang.org/x/net/html"
 	"io"
 	"regexp"
 	"strings"
+	"unicode"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 var (
@@ -13,56 +16,122 @@ var (
 	newlineRe = regexp.MustCompile(`\n\n+`)
 )
 
-func textify(node *html.Node, buf *bytes.Buffer) error {
-	var err error
-	var noRecurse bool
+type textifyTraverseCtx struct {
+	Buf bytes.Buffer
+
+	endsWithSpace bool
+}
+
+func (ctx *textifyTraverseCtx) Traverse(node *html.Node) error {
 	switch node.Type {
+
+	default:
+		return ctx.TraverseChildren(node)
+
 	case html.TextNode:
-		data := strings.Trim(spacingRe.ReplaceAllString(node.Data, " "), "\r\n \t")
-		if len(data) > 0 {
-			if err = buf.WriteByte('\n'); err != nil {
-				return err
-			}
-			if _, err = buf.WriteString(data); err != nil {
-				return err
-			}
-			buf.WriteByte('\n')
-		}
+		data := strings.Trim(spacingRe.ReplaceAllString(node.Data, " "), " ")
+		return ctx.Emit(data)
+
 	case html.ElementNode:
-		for _, attr := range node.Attr {
-			if attr.Key == "href" {
-				if _, err = buf.WriteString(" " + attr.Val); err != nil {
-					return err
-				}
-				noRecurse = true
-				break
-			}
-		}
-	}
-	if !noRecurse {
-		beforeLen := buf.Len()
-		for c := node.FirstChild; c != nil; c = c.NextSibling {
-			if err = textify(c, buf); err != nil {
+
+		switch node.DataAtom {
+		case atom.Br:
+			return ctx.Emit("\n")
+
+		case atom.Li:
+			if err := ctx.Emit("* "); err != nil {
 				return err
 			}
-		}
-		if afterLen := buf.Len(); beforeLen != afterLen {
-			buf.WriteByte('\n')
+
+			if err := ctx.TraverseChildren(node); err != nil {
+				return err
+			}
+
+			return ctx.Emit("\n")
+
+		case atom.A:
+			if err := ctx.TraverseChildren(node); err != nil {
+				return err
+			}
+
+			hrefLink := ""
+			for _, attr := range node.Attr {
+				if attr.Key != "href" {
+					continue
+				}
+
+				attrVal := ctx.NormalizeHrefLink(attr.Val)
+				if attrVal != "" {
+					hrefLink = "( " + attrVal + " )"
+				}
+			}
+
+			return ctx.Emit(hrefLink)
+
+		case atom.P, atom.Ul:
+			if err := ctx.Emit("\n\n"); err != nil {
+				return err
+			}
+
+			if err := ctx.TraverseChildren(node); err != nil {
+				return err
+			}
+
+			return ctx.Emit("\n\n")
+
+		default:
+			return ctx.TraverseChildren(node)
 		}
 	}
+}
+
+func (ctx *textifyTraverseCtx) TraverseChildren(node *html.Node) error {
+	for c := node.FirstChild; c != nil; c = c.NextSibling {
+		if err := ctx.Traverse(c); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
+func (ctx *textifyTraverseCtx) Emit(data string) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	runes := []rune(data)
+	startsWithSpace := unicode.IsSpace(runes[0])
+	if !startsWithSpace && !ctx.endsWithSpace {
+		ctx.Buf.WriteByte(' ')
+	}
+	ctx.endsWithSpace = unicode.IsSpace(runes[len(runes)-1])
+
+	_, err := ctx.Buf.WriteString(data)
+	return err
+}
+
+func (ctx *textifyTraverseCtx) NormalizeHrefLink(link string) string {
+	link = strings.TrimSpace(link)
+	link = strings.TrimPrefix(link, "mailto:")
+	return link
+}
+
 func FromReader(reader io.Reader) (string, error) {
-	buf := &bytes.Buffer{}
 	doc, err := html.Parse(reader)
 	if err != nil {
 		return "", err
 	}
-	if err = textify(doc, buf); err != nil {
+
+	ctx := textifyTraverseCtx{
+		Buf: bytes.Buffer{},
+	}
+	if err = ctx.Traverse(doc); err != nil {
 		return "", err
 	}
-	text := strings.TrimSpace(newlineRe.ReplaceAllString(strings.Replace(buf.String(), "\n ", "\n", -1), "\n\n"))
+
+	text := strings.TrimSpace(newlineRe.ReplaceAllString(
+		strings.Replace(ctx.Buf.String(), "\n ", "\n", -1), "\n\n"))
 	return text, nil
 }
 

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -249,6 +249,49 @@ func TestImageAltTags(t *testing.T) {
 	}
 }
 
+func TestHeadings(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			"<h1>Test</h1>",
+			"****\nTest\n****",
+		},
+		{
+			"\t<h1>\nTest</h1> ",
+			"****\nTest\n****",
+		},
+		{
+			"\t<h1>\nTest line 1<br>Test 2</h1> ",
+			"***********\nTest line 1\nTest 2\n***********",
+		},
+		{
+			"<h1>Test</h1> <h1>Test</h1>",
+			"****\nTest\n****\n\n****\nTest\n****",
+		},
+		{
+			"<h2>Test</h2>",
+			"----\nTest\n----",
+		},
+		{
+			"<h1><a href='http://example.com/'>Test</a></h1>",
+			"****************************\nTest ( http://example.com/ )\n****************************",
+		},
+		{
+			"<h3> <span class='a'>Test </span></h3>",
+			"Test\n----",
+		},
+	}
+
+	for _, testCase := range testCases {
+		fmt.Printf("  testCase: <%s> <%s>\n", testCase.input, testCase.output)
+		assertString(t, testCase.input, testCase.output)
+		fmt.Printf("\n\n")
+	}
+
+}
+
 func TestText(t *testing.T) {
 	testCases := []struct {
 		input string

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -202,6 +202,53 @@ func TestLinks(t *testing.T) {
 	}
 }
 
+func TestImageAltTags(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			`<img />`,
+			``,
+		},
+		{
+			`<img src="http://example.ru/hello.jpg" />`,
+			``,
+		},
+		{
+			`<img alt="Example"/>`,
+			``,
+		},
+		{
+			`<img src="http://example.ru/hello.jpg" alt="Example"/>`,
+			``,
+		},
+		// Images do matter if they are in a link
+		{
+			`<a href="http://example.com/"><img src="http://example.ru/hello.jpg" alt="Example"/></a>`,
+			`Example ( http://example.com/ )`,
+		},
+		{
+			`<a href="http://example.com/"><img src="http://example.ru/hello.jpg" alt="Example"></a>`,
+			`Example ( http://example.com/ )`,
+		},
+		{
+			`<a href='http://example.com/'><img src='http://example.ru/hello.jpg' alt='Example'/></a>`,
+			`Example ( http://example.com/ )`,
+		},
+		{
+			`<a href='http://example.com/'><img src='http://example.ru/hello.jpg' alt='Example'></a>`,
+			`Example ( http://example.com/ )`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		fmt.Printf("  testCase: <%s> <%s>\n", testCase.input, testCase.output)
+		assertString(t, testCase.input, testCase.output)
+		fmt.Printf("\n\n")
+	}
+}
+
 func TestText(t *testing.T) {
 	testCases := []struct {
 		input string

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -1,9 +1,206 @@
 package html2text
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 )
+
+func TestStrippingWhitespace(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			"test text",
+			"test text",
+		},
+		{
+			"  \ttext\ntext\n",
+			"text text",
+		},
+		{
+			"  \na \n\t \n \n a \t",
+			"a a",
+		},
+		{
+			"test        text",
+			"test text",
+		},
+		{
+			"test&nbsp;&nbsp;&nbsp; text&nbsp;",
+			"test    text",
+		},
+	}
+
+	for _, testCase := range testCases {
+		fmt.Printf("  testCase: <%s> <%s>\n", testCase.input, testCase.output)
+		assertString(t, testCase.input, testCase.output)
+		fmt.Printf("\n\n")
+	}
+}
+
+func TestParagraphsAndBreaks(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			"Test text",
+			"Test text",
+		},
+		{
+			"Test text<br>",
+			"Test text",
+		},
+		{
+			"Test text<br>Test",
+			"Test text\nTest",
+		},
+		{
+			"<p>Test text</p>",
+			"Test text",
+		},
+		{
+			"<p>Test text</p><p>Test text</p>",
+			"Test text\n\nTest text",
+		},
+		{
+			"\n<p>Test text</p>\n\n\n\t<p>Test text</p>\n",
+			"Test text\n\nTest text",
+		},
+		{
+			"\n<p>Test text<br/>Test text</p>\n",
+			"Test text\nTest text",
+		},
+		{
+			"\n<p>Test text<br> \tTest text<br></p>\n",
+			"Test text\nTest text",
+		},
+		{
+			"Test text<br><BR />Test text",
+			"Test text\n\nTest text",
+		},
+	}
+
+	for _, testCase := range testCases {
+		fmt.Printf("  testCase: <%s>\n", testCase.input)
+		assertString(t, testCase.input, testCase.output)
+		fmt.Printf("\n\n")
+	}
+}
+
+func TestStrippingLists(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			"<ul></ul>",
+			"",
+		},
+		{
+			"<ul><li>item</li></ul>_",
+			"* item\n\n_",
+		},
+		{
+			"<li class='123'>item 1</li> <li>item 2</li>\n_",
+			"* item 1\n* item 2\n_",
+		},
+		{
+			"<li>item 1</li> \t\n <li>item 2</li> <li> item 3</li>\n_",
+			"* item 1\n* item 2\n* item 3\n_",
+		},
+	}
+
+	for _, testCase := range testCases {
+		fmt.Printf("  testCase: <%s> <%s>\n", testCase.input, testCase.output)
+		assertString(t, testCase.input, testCase.output)
+		fmt.Printf("\n\n")
+	}
+}
+
+func TestLinks(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			`<a></a>`,
+			``,
+		},
+		{
+			`<a href=""></a>`,
+			``,
+		},
+		{
+			`<a href="http://example.com/"></a>`,
+			`( http://example.com/ )`,
+		},
+		{
+			`<a href="">Link</a>`,
+			`Link`,
+		},
+		{
+			`<a href="http://example.com/">Link</a>`,
+			`Link ( http://example.com/ )`,
+		},
+		{
+			`<a href="http://example.com/"><span class="a">Link</span></a>`,
+			`Link ( http://example.com/ )`,
+		},
+		{
+			"<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>",
+			`Link ( http://example.com/ )`,
+		},
+		{
+			"<a href='mailto:contact@example.org'>Contact Us</a>",
+			`Contact Us ( contact@example.org )`,
+		},
+		{
+			"<a href=\"http://example.com:80/~user?aaa=bb&amp;c=d,e,f#foo\">Link</a>",
+			`Link ( http://example.com:80/~user?aaa=bb&c=d,e,f#foo )`,
+		},
+		{
+			"<a title='title' href=\"http://example.com/\">Link</a>",
+			`Link ( http://example.com/ )`,
+		},
+		{
+			"<a href=\"   http://example.com/ \"> Link </a>",
+			`Link ( http://example.com/ )`,
+		},
+		{
+			"<a href=\"http://example.com/a/\">Link A</a> <a href=\"http://example.com/b/\">Link B</a>",
+			`Link A ( http://example.com/a/ ) Link B ( http://example.com/b/ )`,
+		},
+		{
+			"<a href=\"%%LINK%%\">Link</a>",
+			`Link ( %%LINK%% )`,
+		},
+		{
+			"<a href=\"[LINK]\">Link</a>",
+			`Link ( [LINK] )`,
+		},
+		{
+			"<a href=\"{LINK}\">Link</a>",
+			`Link ( {LINK} )`,
+		},
+		{
+			"<a href=\"[[!unsubscribe]]\">Link</a>",
+			`Link ( [[!unsubscribe]] )`,
+		},
+		{
+			"<p>This is <a href=\"http://www.google.com\" >link1</a> and <a href=\"http://www.google.com\" >link2 </a> is next.</p>",
+			`This is link1 ( http://www.google.com ) and link2 ( http://www.google.com ) is next.`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		fmt.Printf("  testCase: <%s> <%s>\n", testCase.input, testCase.output)
+		assertString(t, testCase.input, testCase.output)
+		fmt.Printf("\n\n")
+	}
+}
 
 func TestText(t *testing.T) {
 	testCases := []struct {
@@ -12,9 +209,9 @@ func TestText(t *testing.T) {
 	}{
 		{
 			`<li>
-  <a href="/new" data-ga-click="Header, create new repository, icon:repo"><span class="octicon octicon-repo"></span> New repository</a>
-</li>`,
-			`/new`,
+		  <a href="/new" data-ga-click="Header, create new repository, icon:repo"><span class="octicon octicon-repo"></span> New repository</a>
+		</li>`,
+			`\* New repository \( /new \)`,
 		},
 		{
 			`hi
@@ -32,17 +229,15 @@ func TestText(t *testing.T) {
 	</ul>
 `,
 			`hi
+hello google \( https://google.com \)
 
-hello
-https://google.com
 test
 
 List:
 
-foo
-http://www.microshwhat.com/bar/soapy
-
-Baz`,
+\* Foo \( foo \)
+\* Barsoap \( http://www.microshwhat.com/bar/soapy \)
+\* Baz`,
 		},
 		// Malformed input html.
 		{
@@ -59,28 +254,65 @@ Baz`,
 		        <li>Baz</li>
 			</ul>
 		`,
-			`hi hello
-https://google.com
-test
+			`hi hello google \( https://google.com \) test
 
 List:
 
-foo
-/\n[ \t]+bar/baz
-
-Baz`,
+\* Foo \( foo \)
+\* Bar \( /\n[ \t]+bar/baz \)
+\* Baz`,
 		},
 	}
 
 	for _, testCase := range testCases {
-		text, err := FromString(testCase.input)
-		if err != nil {
-			t.Error(err)
-		}
-		if expr := regexp.MustCompile(testCase.expr); !expr.MatchString(text) {
-			t.Errorf("Input did not match expression\nInput:\n>>>>\n%s\n<<<<\n\nOutput:\n>>>>\n%s\n<<<<\n\nExpression: %s\n", testCase.input, text, expr.String())
-		} else {
-			t.Logf("input:\n\n%s\n\n\n\noutput:\n\n%s\n", testCase.input, text)
-		}
+		assertRegexp(t, testCase.input, testCase.expr)
+	}
+}
+
+type StringMatcher interface {
+	MatchString(string) bool
+	String() string
+}
+
+type RegexpStringMatcher string
+
+func (m RegexpStringMatcher) MatchString(str string) bool {
+	return regexp.MustCompile(string(m)).MatchString(str)
+}
+func (m RegexpStringMatcher) String() string {
+	return string(m)
+}
+
+type ExactStringMatcher string
+
+func (m ExactStringMatcher) MatchString(str string) bool {
+	return string(m) == str
+}
+func (m ExactStringMatcher) String() string {
+	return string(m)
+}
+
+func assertRegexp(t *testing.T, input string, outputRE string) {
+	assertPlaintext(t, input, RegexpStringMatcher(outputRE))
+}
+
+func assertString(t *testing.T, input string, output string) {
+	assertPlaintext(t, input, ExactStringMatcher(output))
+}
+
+func assertPlaintext(t *testing.T, input string, matcher StringMatcher) {
+	text, err := FromString(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !matcher.MatchString(text) {
+		t.Errorf("Input did not match expression\n"+
+			"Input:\n>>>>\n%s\n<<<<\n\n"+
+			"Output:\n>>>>\n%s\n<<<<\n\n"+
+			"Expected output:\n>>>>\n%s\n<<<<\n\n",
+			input, text, matcher.String())
+	} else {
+		t.Logf("input:\n\n%s\n\n\n\noutput:\n\n%s\n", input, text)
 	}
 }


### PR DESCRIPTION
The format of links and lists has been modify to be as much close
as possible to the format in premailer (https://github.com/premailer/premailer).

Most of the tests are taken from https://github.com/premailer/premailer/blob/master/test/test_html_to_plain_text.rb

TL;DR:
`<a href="http://hr.ef/">Caption</a>` becomes `Caption (http://hr.ef/)`
`<li>1</li><li>2</li>` becomes `* 1\n* 2`