### PR TITLE
Link and period formatting changes

### DIFF
--- a/html2text_test.go
+++ b/html2text_test.go
@@ -453,6 +453,10 @@ func TestLinks(t *testing.T) {
 			"<p>This is <a href=\"http://www.google.com\" >link1</a> and <a href=\"http://www.google.com\" >link2 </a> is next.</p>",
 			`This is link1 ( http://www.google.com ) and link2 ( http://www.google.com ) is next.`,
 		},
+		{
+			"<a href=\"http://www.google.com\" >http://www.google.com</a>",
+			`http://www.google.com`,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -784,6 +788,30 @@ List:
 \* Foo \( foo \)
 \* Bar \( /\n[ \t]+bar/baz \)
 \* Baz`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		if msg, err := wantRegExp(testCase.input, testCase.expr); err != nil {
+			t.Error(err)
+		} else if len(msg) > 0 {
+			t.Log(msg)
+		}
+	}
+}
+
+func TestPeriod(t *testing.T) {
+	testCases := []struct {
+		input string
+		expr  string
+	}{
+		{
+			`<p>Lorem ipsum <span>test</span>.</p>`,
+			`Lorem ipsum test\.`,
+		},
+		{
+			`<p>Lorem ipsum <span>test.</span></p>`,
+			`Lorem ipsum test\.`,
 		},
 	}
 


### PR DESCRIPTION
Changes:
* Don't show link href in parentheses if link is tautological (normalized href matches content).
* Don't add a space prefix before data starting with '.' (also addresses #7 )

This code is a bit hacky but I thought I'd share it anyways. Feel free to merge either change if you think it would be beneficial.

Input:
`<div>If you would like to provide feedback please email <a href='mailto:johndoe@example.com'>johndoe@example.com</a>.</div>`

Original output:
`If you would like to provide feedback please email johndoe@example.com (johndoe@example.com) .`

New output:
`If you would like to provide feedback please email johndoe@example.com.`

Issues:
1. Not i18n.
2. Potential issues with periods in other contexts.
