### PR TITLE
Preserve whitespace in <pre> tags

### DIFF
--- a/html2text_test.go
+++ b/html2text_test.go
@@ -139,6 +139,10 @@ func TestParagraphsAndBreaks(t *testing.T) {
 			"Test text<br><BR />Test text",
 			"Test text\n\nTest text",
 		},
+		{
+			"<pre>test1\ntest 2\n\ntest  3</pre>",
+			"test1\ntest 2\n\ntest  3",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -792,7 +796,7 @@ func TestText(t *testing.T) {
 			`hi
 
 			<br>
-	
+
 	hello <a href="https://google.com">google</a>
 	<br><br>
 	test<p>List:</p>


### PR DESCRIPTION
Html2text seems to discard the whitespace formatting in `<pre>` tags:

input:

```
<pre>test1
test 2

test  3</pre>
```

expected:

```
test1
test 2

test  3
```

actual result:

```
test1 test 2 test 3
```

`<pre>` on MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre *("Whitespace inside this element is displayed as written.")*

Code taken from this patch by @Kleissner: https://github.com/jaytaylor/html2text/issues/6#issuecomment-329620709Q, with `atom.Code` removed (as `<code>` does not actually preserve whitespace in browsers).

Added a simple test case with newlines and multiple spaces.

Fixes #6, also fixes #22.