### PR TITLE
CitationStyleLinks, OmitTableNodes options

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[.*]
+charset: utf-8
+end_of_line: lf
+
+[*.go]
+indent_style = tab

--- a/html2text.go
+++ b/html2text.go
@@ -16,6 +16,7 @@ import (
 
 // Options provide toggles and overrides to control specific rendering behaviors.
 type Options struct {
+	OmitTableNodes     bool // Turns on omitting tables and any content inside
 	PrettyTables       bool // Turns on pretty ASCII rendering for table elements.
 	OmitLinks          bool // Turns on omitting links
 	CitationStyleLinks bool // Uses citation style links like [1]
@@ -243,12 +244,16 @@ func (ctx *textifyTraverseContext) handleElement(node *html.Node) error {
 		return ctx.paragraphHandler(node)
 
 	case atom.Table, atom.Tfoot, atom.Th, atom.Tr, atom.Td:
-		if ctx.options.PrettyTables {
-			return ctx.handleTableElement(node)
-		} else if node.DataAtom == atom.Table {
-			return ctx.paragraphHandler(node)
+		if !ctx.options.OmitTableNodes {
+			if ctx.options.PrettyTables {
+				return ctx.handleTableElement(node)
+			} else if node.DataAtom == atom.Table {
+				return ctx.paragraphHandler(node)
+			}
+			return ctx.traverseChildren(node)
+		} else {
+			return ctx.emit("\n\n[Table]\n\n")
 		}
-		return ctx.traverseChildren(node)
 
 	case atom.Pre:
 		ctx.isPre = true

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -520,6 +520,54 @@ func TestOmitLinks(t *testing.T) {
 	}
 }
 
+func TestCitationStyleLinks(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			`<a></a>`,
+			``,
+		},
+		{
+			`<a href=""></a>`,
+			``,
+		},
+		{
+			`<a href="http://example.com/"></a>`,
+			"[1]\n\n[1] http://example.com/",
+		},
+		{
+			`<a href="">Link</a>`,
+			"Link",
+		},
+		{
+			`<a href="http://example1.com/">Link1</a><a href="http://example2.com/">Link2</a>`,
+			"Link1 [1] Link2 [2]\n\n[1] http://example1.com/\n[2] http://example2.com/",
+		},
+		{
+			`<a href="http://example.com/"><span class="a">Link</span></a>`,
+			"Link [1]\n\n[1] http://example.com/",
+		},
+		{
+			"<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>",
+			"Link [1]\n\n[1] http://example.com/",
+		},
+		{
+			`<a href="http://example.com/"><img src="http://example.ru/hello.jpg" alt="Example"></a>`,
+			"Example [1]\n\n[1] http://example.com/",
+		},
+	}
+
+	for _, testCase := range testCases {
+		if msg, err := wantString(testCase.input, testCase.output, Options{CitationStyleLinks: true}); err != nil {
+			t.Error(err)
+		} else if len(msg) > 0 {
+			t.Log(msg)
+		}
+	}
+}
+
 func TestImageAltTags(t *testing.T) {
 	testCases := []struct {
 		input  string


### PR DESCRIPTION
### Citation Style Links

Example:

```html
Here is a <a href="http://example.com/">link</a> to some page and <a href="http://google.com">another link</a> too
```

Output:
```
Here is a link [1] to some page and another link [2] too

[1] http://example.com
[2] http://google.com
```

### Omit Table Nodes

Just like the `OmitLinks` option, but for tables. Inserts a "[Table]" text in the place of the table.