### PR TITLE
Updated Travis CI Golang testing versions for 2020.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: go
 go:
+  # n.b. For golang release history, see https://golang.org/doc/devel/release.html
   - tip
-  - 1.8
-  - 1.7
-  - 1.6
-  - 1.5
-  - 1.4
-  - 1.3
-  - 1.2
+  - "1.13.8"
+  - "1.12.17"
+  - "1.11.13"
+  - "1.10.8"
+  - "1.9.7"
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
- Added Go versions 1.9.7, 1.10.8, 1.11.13, 1.12.17, and 1.13.8.
- Dropped Go versions 1.2, 1.3, 1.4, 1.5, 1.6, 1.7 and 1.8.
