### PR TITLE
Support citation style links

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -2,6 +2,7 @@ package html2text
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -18,6 +19,7 @@ type Options struct {
 	PrettyTables        bool                 // Turns on pretty ASCII rendering for table elements.
 	PrettyTablesOptions *PrettyTablesOptions // Configures pretty ASCII rendering for table elements.
 	OmitLinks           bool                 // Turns on omitting links
+	CitationStyleLinks  bool                 // Uses citation style links like [1]
 }
 
 // PrettyTablesOptions overrides tablewriter behaviors
@@ -72,9 +74,14 @@ func FromHTMLNode(doc *html.Node, o ...Options) (string, error) {
 	ctx := textifyTraverseContext{
 		buf:     bytes.Buffer{},
 		options: options,
+		citationMap: map[string]int{},
 	}
 	if err := ctx.traverse(doc); err != nil {
 		return "", err
+	}
+
+	if ctx.options.CitationStyleLinks && ctx.citationCount > 0 {
+		ctx.emitCitations()
 	}
 
 	text := strings.TrimSpace(newlineRe.ReplaceAllString(
@@ -124,6 +131,8 @@ type textifyTraverseContext struct {
 	blockquoteLevel int
 	lineLength      int
 	isPre           bool
+	citationCount   int
+	citationMap     map[string]int
 }
 
 // tableTraverseContext holds table ASCII-form related context.
@@ -255,7 +264,11 @@ func (ctx *textifyTraverseContext) handleElement(node *html.Node) error {
 			attrVal = ctx.normalizeHrefLink(attrVal)
 			// Don't print link href if it matches link element content or if the link is empty.
 			if !ctx.options.OmitLinks && attrVal != "" && linkText != attrVal {
-				hrefLink = "( " + attrVal + " )"
+				if ctx.options.CitationStyleLinks {
+					hrefLink = ctx.addCitation(attrVal)
+				} else {
+					hrefLink = "( " + attrVal + " )"
+				}
 			}
 		}
 
@@ -501,6 +514,40 @@ func (ctx *textifyTraverseContext) normalizeHrefLink(link string) string {
 	link = strings.TrimSpace(link)
 	link = strings.TrimPrefix(link, "mailto:")
 	return link
+}
+
+func formatCitation(idx int) string {
+	return fmt.Sprintf("[%d] ", idx)
+}
+
+func (ctx *textifyTraverseContext) addCitation(url string) string {
+	idx, ok := ctx.citationMap[url]
+
+	if !ok {
+		ctx.citationCount += 1
+		idx = ctx.citationCount
+		ctx.citationMap[url] = idx
+	}
+
+	return formatCitation(idx)
+}
+
+func (ctx *textifyTraverseContext) emitCitations() {
+	// this method writes to the buffer directly instead of using `emit`, b/c we do not want to split long links
+	ctx.buf.WriteString("\n\n")
+
+	// citations are ordered by link --> bring them into the correct order first
+	links := make([]string, ctx.citationCount)
+
+	for k, v := range ctx.citationMap {
+		links[v-1] = k // arrays are 0-based, our citations are 1-based
+	}
+
+	for i, link := range links {
+		ctx.buf.WriteString(formatCitation(i + 1))
+		ctx.buf.WriteString(link)
+		ctx.buf.WriteByte('\n')
+	}
 }
 
 // renderEachChild visits each direct child of a node and collects the sequence of

--- a/html2text.go
+++ b/html2text.go
@@ -517,7 +517,7 @@ func (ctx *textifyTraverseContext) normalizeHrefLink(link string) string {
 }
 
 func formatCitation(idx int) string {
-	return fmt.Sprintf("[%d] ", idx)
+	return fmt.Sprintf("[%d]", idx)
 }
 
 func (ctx *textifyTraverseContext) addCitation(url string) string {
@@ -545,6 +545,7 @@ func (ctx *textifyTraverseContext) emitCitations() {
 
 	for i, link := range links {
 		ctx.buf.WriteString(formatCitation(i + 1))
+		ctx.buf.WriteByte(' ')
 		ctx.buf.WriteString(link)
 		ctx.buf.WriteByte('\n')
 	}

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -536,31 +536,31 @@ func TestCitationStyleLinks(t *testing.T) {
 		},
 		{
 			`<a href="http://example.com/"></a>`,
-			"[1] \n\n[1] http://example.com/",
+			"[1]\n\n[1] http://example.com/",
 		},
 		{
 			`<a href="">Link</a>`,
 			"Link",
 		},
 		{
-			`<a href="http://example1.com/">Link1</a><a href="http://example2.com/">Link2</a>`,
-			"Link1 [1] Link2 [2] \n\n[1] http://example1.com/\n[2] http://example2.com/",
+			`<a href="http://example1.com/">Link1</a>? <a href="http://example2.com/">Link2</a>!`,
+			"Link1 [1]? Link2 [2]!\n\n[1] http://example1.com/\n[2] http://example2.com/",
 		},
 		{
 			`<a href="http://example1.com/">Link1</a><a href="http://example1.com/">Link1 again</a>`,
-			"Link1 [1] Link1 again [1] \n\n[1] http://example1.com/",
+			"Link1 [1] Link1 again [1]\n\n[1] http://example1.com/",
 		},
 		{
 			`<a href="http://example.com/"><span class="a">Link</span></a>`,
-			"Link [1] \n\n[1] http://example.com/",
+			"Link [1]\n\n[1] http://example.com/",
 		},
 		{
 			"<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>",
-			"Link [1] \n\n[1] http://example.com/",
+			"Link [1]\n\n[1] http://example.com/",
 		},
 		{
 			`<a href="http://example.com/"><img src="http://example.ru/hello.jpg" alt="Example"></a>`,
-			"Example [1] \n\n[1] http://example.com/",
+			"Example [1]\n\n[1] http://example.com/",
 		},
 	}
 

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -521,6 +521,58 @@ func TestOmitLinks(t *testing.T) {
 	}
 }
 
+func TestCitationStyleLinks(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{
+		{
+			`<a></a>`,
+			``,
+		},
+		{
+			`<a href=""></a>`,
+			``,
+		},
+		{
+			`<a href="http://example.com/"></a>`,
+			"[1] \n\n[1] http://example.com/",
+		},
+		{
+			`<a href="">Link</a>`,
+			"Link",
+		},
+		{
+			`<a href="http://example1.com/">Link1</a><a href="http://example2.com/">Link2</a>`,
+			"Link1 [1] Link2 [2] \n\n[1] http://example1.com/\n[2] http://example2.com/",
+		},
+		{
+			`<a href="http://example1.com/">Link1</a><a href="http://example1.com/">Link1 again</a>`,
+			"Link1 [1] Link1 again [1] \n\n[1] http://example1.com/",
+		},
+		{
+			`<a href="http://example.com/"><span class="a">Link</span></a>`,
+			"Link [1] \n\n[1] http://example.com/",
+		},
+		{
+			"<a href='http://example.com/'>\n\t<span class='a'>Link</span>\n\t</a>",
+			"Link [1] \n\n[1] http://example.com/",
+		},
+		{
+			`<a href="http://example.com/"><img src="http://example.ru/hello.jpg" alt="Example"></a>`,
+			"Example [1] \n\n[1] http://example.com/",
+		},
+	}
+
+	for _, testCase := range testCases {
+		if msg, err := wantString(testCase.input, testCase.output, Options{CitationStyleLinks: true}); err != nil {
+			t.Error(err)
+		} else if len(msg) > 0 {
+			t.Log(msg)
+		}
+	}
+}
+
 func TestImageAltTags(t *testing.T) {
 	testCases := []struct {
 		input  string

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -543,6 +543,14 @@ func TestCitationStyleLinks(t *testing.T) {
 			"Link",
 		},
 		{
+			`<a href="http://example1.com/">Link1</a><a href="http://example2.com/">Link2</a>`,
+			"Link1 [1] Link2 [2]\n\n[1] http://example1.com/\n[2] http://example2.com/",
+		},
+		{
+			`<a href="http://example1.com/">Link1</a> (<a href="http://example2.com/">Link2</a>)`,
+			"Link1 [1] (Link2 [2])\n\n[1] http://example1.com/\n[2] http://example2.com/",
+		},
+		{
 			`<a href="http://example1.com/">Link1</a>? <a href="http://example2.com/">Link2</a>!`,
 			"Link1 [1]? Link2 [2]!\n\n[1] http://example1.com/\n[2] http://example2.com/",
 		},


### PR DESCRIPTION
This PR is similar to #32, with the following deviations:
- only citation style links, no omitTableNodes etc
- multiple links to the same URL get the same citation index (just as citations work :))
- write directly into the buffer instead of string concatenation in a loop

Also, as a side effect, when determining where to add spaces, punctuation is taken into account. That is, no spaces are added before '?', ')', ... and no spaces are added after '(', '[', ...

Thus
```html
Here is a <a href="http://example.com/">link</a> to some page. And <a href="http://google.com">another link</a>, too. 
And the <a href="http://example.com">first link</a> again.
```
renders as
```
Here is a link [1] to some page. And another link [2], too.
And the first link [1] again.

[1] http://example.com
[2] http://google.com
```