### PR TITLE
Minimum column width support. Support for the "noWhiteSpace" option in the tablewriter package.

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -33,6 +33,7 @@ type PrettyTablesOptions struct {
 	FooterAlignment      int
 	Alignment            int
 	ColumnAlignment      []int
+	NoWhiteSapce         bool
 	NewLine              string
 	HeaderLine           bool
 	RowLine              bool
@@ -54,6 +55,7 @@ func NewPrettyTablesOptions() *PrettyTablesOptions {
 		FooterAlignment:      tablewriter.ALIGN_DEFAULT,
 		Alignment:            tablewriter.ALIGN_DEFAULT,
 		ColumnAlignment:      []int{},
+		NoWhiteSapce:         false,
 		NewLine:              tablewriter.NEWLINE,
 		HeaderLine:           true,
 		RowLine:              false,
@@ -338,6 +340,7 @@ func (ctx *textifyTraverseContext) handleTableElement(node *html.Node) error {
 			table.SetRowLine(options.RowLine)
 			table.SetAutoMergeCells(options.AutoMergeCells)
 			table.SetBorders(options.Borders)
+			table.SetNoWhiteSpace(options.NoWhiteSapce)
 		}
 		table.SetHeader(ctx.tableCtx.header)
 		table.SetFooter(ctx.tableCtx.footer)

--- a/html2text_test.go
+++ b/html2text_test.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/olekukonko/tablewriter"
 )
 
 const destPath = "testdata"
@@ -337,6 +339,7 @@ Table 2 Header 1 Table 2 Header 2 Table 2 Footer 1 Table 2 Footer 2 Table 2 Row 
 			PrettyTables:        true,
 			PrettyTablesOptions: NewPrettyTablesOptions(),
 		}
+
 		// Check pretty tabular ASCII version.
 		if msg, err := wantString(testCase.input, testCase.tabularOutput, options); err != nil {
 			t.Error(err)
@@ -351,6 +354,79 @@ Table 2 Header 1 Table 2 Header 2 Table 2 Footer 1 Table 2 Footer 2 Table 2 Row 
 			t.Log(msg)
 		}
 	}
+}
+
+func TestMinColWidthTable(t *testing.T) {
+	testCases := []struct {
+		input           string
+		tabularOutput   string
+		plaintextOutput string
+		alignment       string
+	}{
+		{
+			"<table><tr><td>Hello</td><td>World!</td></tr></table>",
+			// Empty table
+			// +--+--+
+			// |  |  |
+			// +--+--+
+			"+------------+------------+\n| Hello      | World!     |\n+------------+------------+",
+			"Hello World!",
+			"Left",
+		},
+		{
+			"<table><tr><td>Hello</td><td>World!</td></tr></table>",
+			// Empty table
+			// +--+--+
+			// |  |  |
+			// +--+--+
+			"+------------+------------+\n|      Hello |     World! |\n+------------+------------+",
+			"Hello World!",
+			"Right",
+		},
+		{
+			"<table><tr><td>Hello</td><td>World!</td></tr></table>",
+			// Empty table
+			// +--+--+
+			// |  |  |
+			// +--+--+
+			"+------------+------------+\n|   Hello    |   World!   |\n+------------+------------+",
+			"Hello World!",
+			"Center",
+		},
+	}
+
+	for _, testCase := range testCases {
+		options := Options{
+			PrettyTables:        true,
+			PrettyTablesOptions: NewPrettyTablesOptions(),
+		}
+		options.PrettyTablesOptions.MinColWidth = 10
+
+		switch testCase.alignment {
+		case "Left":
+			options.PrettyTablesOptions.Alignment = tablewriter.ALIGN_LEFT
+		case "Right":
+			options.PrettyTablesOptions.Alignment = tablewriter.ALIGN_RIGHT
+		case "Center":
+			options.PrettyTablesOptions.Alignment = tablewriter.ALIGN_CENTER
+		default:
+			options.PrettyTablesOptions.Alignment = tablewriter.ALIGN_DEFAULT
+		}
+		// Check pretty tabular ASCII version.
+		if msg, err := wantString(testCase.input, testCase.tabularOutput, options); err != nil {
+			t.Error(err)
+		} else if len(msg) > 0 {
+			t.Log(msg)
+		}
+
+		// Check plain version.
+		if msg, err := wantString(testCase.input, testCase.plaintextOutput); err != nil {
+			t.Error(err)
+		} else if len(msg) > 0 {
+			t.Log(msg)
+		}
+	}
+
 }
 
 func TestStrippingLists(t *testing.T) {


### PR DESCRIPTION
Added code and tests. 

Setting the minimum column width will ensure that all outputted columns are at least that number of characters wide (plus cell padding). It makes some tables easier to read.

The tablewriter package now includes a noWhiteSpace option, which I added to the pretty tables options too.

There's one additional function that isn't used at the moment that made it into the commit as well.