### PR TITLE
do not add punctuation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# editor files
+.idea

--- a/html2text.go
+++ b/html2text.go
@@ -159,7 +159,7 @@ func (ctx *textifyTraverseContext) handleElement(node *html.Node) error {
 
 		str := subCtx.buf.String()
 		if ctx.options.TextOnly {
-			return ctx.emit(str + ".\n\n")
+			return ctx.emit(str + "\n\n")
 		}
 		dividerLen := 0
 		for _, line := range strings.Split(str, "\n") {


### PR DESCRIPTION
When writing the headers to the output there is no need to add punctation. The extracted text shoudl not have
anything that is not in the actual text.

In addition I updated the .gitignore to exclude .idea files -this is generated by my editor.