### PR TITLE
Fix OmitLinks support

### DIFF
--- a/html2text.go
+++ b/html2text.go
@@ -267,7 +267,7 @@ func (ctx *textifyTraverseContext) handleElement(node *html.Node) error {
 		if attrVal := getAttrVal(node, "href"); attrVal != "" {
 			attrVal = ctx.normalizeHrefLink(attrVal)
 			// Don't print link href if it matches link element content or if the link is empty.
-			if (!ctx.options.OmitLinks && attrVal != "" && linkText != attrVal) || !ctx.options.TextOnly {
+			if (attrVal != "" && linkText != attrVal) && !ctx.options.OmitLinks && !ctx.options.TextOnly {
 				hrefLink = "( " + attrVal + " )"
 			}
 		}


### PR DESCRIPTION
It seems that the last change, to add TextOnly support, broke OmitLinks.  I think this should fix it.